### PR TITLE
Fix ChatAssistant prompt parsing

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -81,8 +81,9 @@ class ChatAssistant:
 
     def makeChatRespPrompt(self, msg):
         author = msg['author']['global_name']
-        content = msg['content'].replace("!gpt ", "").strip()
-        content = msg['content'].replace(f"<@{self.bot_id}>", f"@{self.bot_name}").strip()
+        content = msg['content']
+        content = content.replace("!gpt ", "").strip()
+        content = content.replace(f"<@{self.bot_id}>", f"@{self.bot_name}").strip()
         prompt = f"{author}: {content}"
         return prompt
 

--- a/frigbot.py
+++ b/frigbot.py
@@ -199,9 +199,8 @@ class Frig:
         split_completion = completion.replace("\n\n", "\n").strip().split("<split>")
 
         resps = self.send(split_completion, reply_msg_id = msg_id)
-        #for comp, resp in zip(split_completion, resps):
-        for resp in resps:
-            self.asst.addMessage("assistant", completion, resp["id"], msg_id)
+        for comp, resp in zip(split_completion, resps):
+            self.asst.addMessage("assistant", comp, resp["id"], msg_id)
 
     def gpt_img_resp(self, msg):
         prompt = msg['content'].replace("!img", "").strip()


### PR DESCRIPTION
## Summary
- chain text replacements for chat prompts so both `!gpt` and bot mentions are removed
- store each split chat completion when logging assistant messages

## Testing
- `python3 -m py_compile chat.py completions.py frigbot.py lolManager.py run.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_683f47ad9f6883328d4c4822427ac5c8