### PR TITLE
Push mobile app content below Discord's activity overlay

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -497,7 +497,10 @@ button.primary { background: #5865f2; color: #fff; border-color: #5865f2; }
 /* Mobile / narrow viewports */
 @media (max-width: 720px) {
   .app {
-    padding: 6px;
+    /* Discord's mobile activity overlay (join/leave bar) sits at the top of
+       the iframe and covers our tab switcher. Push content down so the tabs
+       clear it; respect the device safe-area inset on top of that. */
+    padding: calc(48px + env(safe-area-inset-top)) 6px 6px;
     gap: 6px;
   }
 


### PR DESCRIPTION
On mobile, Discord renders an overlay topbar (join/leave activity
buttons) at the top of the activity iframe, covering the Wordle/
Connections tab switcher so it can't be tapped. Add top padding on
narrow viewports so the tabs clear the overlay, plus the safe-area
inset.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RyNYhHR7Xv8djBVovF8Hjo